### PR TITLE
fixed: Lists are not currently supported in HTML input for Django Rest Framework, using alternative

### DIFF
--- a/estimates/migrations/0001_initial.py
+++ b/estimates/migrations/0001_initial.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='EstimateItems',
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('quoteitems_id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('offered_quantity_to_customer', models.PositiveIntegerField()),
                 ('selling_price_proposed_to_customer', models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True)),
                 ('product', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='items.item')),

--- a/estimates/models.py
+++ b/estimates/models.py
@@ -66,10 +66,12 @@ class Estimates(models.Model):
         return self.estimate_number
 
 class EstimateItems(models.Model):
+    quoteitems_id = models.AutoField(primary_key=True)
     estimate = models.ForeignKey(Estimates, related_name='items', on_delete=models.CASCADE)
     product = models.ForeignKey(Item, on_delete=models.CASCADE)
     offered_quantity_to_customer = models.PositiveIntegerField()
     selling_price_proposed_to_customer = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
 
     def __str__(self):
-        return f'{self.estimate.estimate_number} - {self.product}'
+        #return f'{self.estimate.estimate_number} - {self.product}'
+        return self.product

--- a/estimates/serializers.py
+++ b/estimates/serializers.py
@@ -11,28 +11,10 @@ class EstimateItemSerializer(serializers.ModelSerializer):
     class Meta:
         model = EstimateItems
         fields = ['product', 'offered_quantity_to_customer', 'selling_price_proposed_to_customer']
-        #fields = '__all__'
-        #depth = 1 #includes item details in serialization
 
 class EstimateSerializer(serializers.ModelSerializer):
-    #items = EstimateItemSerializer(many=True)
-    items = serializers.PrimaryKeyRelatedField(queryset=Item.objects.all())
-
-#     ITEMS_CHOICES =(  
-#     ("1", "One"),  
-#     ("2", "Two"),  
-#     ("3", "Three"),  
-#     ("4", "Four"),  
-#     ("5", "Five"),  
-# ) 
-
-    #items = EstimateItemSerializer(many=True)
-    # items = serializers.MultipleChoiceField(choices = ITEMS_CHOICES,
-    #     style = {
-    #         'base_temolate': 'select_multiple.html', 'rows': 10
-    #     }
-    # )
-    #customer_id = serializers.IntegerField(write_only=True)
+    items = EstimateItemSerializer(many=True)
+    
     class Meta:
         model = Estimates
         fields = ['estimate_number', 'customer', 'estimate_date', 'offer_expiry_date', 'items']
@@ -41,8 +23,6 @@ class EstimateSerializer(serializers.ModelSerializer):
         items_data = validated_data.pop('items')
         estimate = Estimates.objects.create(**validated_data)
         for item_data in items_data:
-            # product_data = item_data.pop('product')
-            # product, _ = Item.objects.get_or_create(**product_data)
             EstimateItems.objects.create(estimate=estimate, **item_data)
         return estimate
 

--- a/estimates/templates/estimates/estimates_list.html
+++ b/estimates/templates/estimates/estimates_list.html
@@ -1,0 +1,26 @@
+{% load rest_framework %}
+
+html>
+<head>
+    <title>Estimate Form</title>
+</head>
+<body>
+    <h1>Estimate List</h1>
+    <ul>
+        {% for estimate in estimates %}
+            <li>
+                <strong>estimate number:</strong> {{ estimate.estimate_number }}<br>
+                <strong>customer:</strong> {{ estimate.customer }}<br>
+                <strong>estimate_date:</strong> {{ estimate.estimate_date }}<br>
+                <strong>offer expiry date:</strong> {{ estimate.offer_expiry_date }}<br>
+                <strong>items:</strong>
+                <ul>
+                    {% for item in estimates.items.all %}
+                        <li>{{ car }}</li> <!-- Adjust according to your Car model fields -->
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/estimates/urls.py
+++ b/estimates/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
-from estimates.views import EstimateListCreateView, EstimateRetrieveUpdateDeleteView, estimate_pdf_creation_view, EstimateCreationView, EstimateDetailView
+from estimates.views import EstimateRetrieveUpdateDeleteView, estimate_pdf_creation_view, EstimateCreationView, EstimateDetailView, estimates_index
 
 
 urlpatterns = [
-    path('', EstimateListCreateView.as_view(), name='estimate-list-create'),
+    #path('', EstimateListCreateView.as_view(), name='estimate-list-create'),
     path('<int:pk>/', EstimateRetrieveUpdateDeleteView.as_view(), name='estimate-retrieve-update-delete'),
     path('pdf/', estimate_pdf_creation_view, name='estimate-pdf-creation'),
     path('create_estimate/', EstimateCreationView.as_view(), name='create-estimate'),
     path('detail_estimate/<int:estimate_id>/', EstimateDetailView.as_view(), name='estimate-detail'),
+    path('index/', estimates_index, name='estimates-index'),
 ]

--- a/estimates/views.py
+++ b/estimates/views.py
@@ -24,13 +24,22 @@ class EstimateCreationView(APIView):
     
     def post(self, request):
         data = request.data
-        serializer = EstimateSerializer(data=data)
+        serializer = EstimateSerializer(data=request.data)
         #print(serializer.data)
         if serializer.is_valid():
             #input_data = serializer.validated_data
             serializer.save()
-            return Response({'serializer': serializer})
+            #return Response({'serializer': self.serializer.data}, template_name='estimate_form.html')
+            queryset = Estimates.objects.all()
+            return Response({
+                'estimate': queryset,
+                'message': 'Estimate succesfully created',
+            }, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    
+    def get(self, request):
+        queryset = Estimates.objects.all()
+        return Response({'estimates': queryset})
 
     
     
@@ -59,6 +68,9 @@ def estimate_pdf_creation_view(request):
     p.save()
     buffer.seek(0)
     return FileResponse(buffer, as_attachment=True, filename='estimate.pdf')
+
+def estimates_index(request):
+    return render(request, 'estimates/estimates_list.html')
 
 
 


### PR DESCRIPTION
1. altering: estimateitems model by changing the primary key and returning product name
2. adding: estimates migration files
3. adding: estimates list and its url path for template testing
4. adding: latest migration files for estimates
5. modifying: estimate creation by rendering estimates queryset and adding get method