### PR TITLE
bug found: dynamic content generation for estimates pdf

### DIFF
--- a/estimates/urls.py
+++ b/estimates/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from estimates.views import EstimateListCreateView, EstimateRetrieveUpdateDeleteView, estimate_pdf_creation_view, EstimateCreationView, EstimateDetailView, estimates_index
+from estimates.views import EstimateListCreateView, EstimateRetrieveUpdateDeleteView, estimate_pdf_creation_view, EstimateCreationView, EstimateDetailView, estimates_index, PdfGenerationView
 
 
 urlpatterns = [
@@ -8,5 +8,6 @@ urlpatterns = [
     path('pdf/', estimate_pdf_creation_view, name='estimate-pdf-creation'),
     path('create_estimate/', EstimateCreationView.as_view(), name='create-estimate'),
     path('detail_estimate/<int:estimate_id>/', EstimateDetailView.as_view(), name='estimate-detail'),
+    path('generate_pdf/<int:estimate_id>/', PdfGenerationView.as_view(), name='generate-pdf'),
     #path('index/', estimates_index, name='estimates-index'),
 ]

--- a/estimates/views.py
+++ b/estimates/views.py
@@ -1,7 +1,11 @@
 from django.shortcuts import render, redirect, get_object_or_404
+from django.views import View
+from django.utils.html import strip_tags
+from django.http import HttpResponse
 from rest_framework import generics, viewsets, status, serializers
 from rest_framework.views import APIView
 from rest_framework.response import Response 
+from reportlab.lib.pagesizes import letter
 from rest_framework.renderers import TemplateHTMLRenderer, JSONRenderer, BrowsableAPIRenderer
 from estimates.models import Estimates, EstimateItems
 from estimates.serializers import EstimateSerializer
@@ -10,6 +14,7 @@ from estimates.forms import EstimateForm
 #from django.template.response import SimpleTemplateResponse
 import io
 from django.http import FileResponse
+from django.template.loader import render_to_string
 from reportlab.pdfgen import canvas
 
 # Create your views here.
@@ -59,6 +64,27 @@ class EstimateRetrieveUpdateDeleteView(generics.RetrieveUpdateDestroyAPIView):
 class EstimateViewSet(viewsets.ModelViewSet):
     queryset = Estimates.objects.all()
     serializer_class = EstimateSerializer
+
+class PdfGenerationView(View):
+    def get(self, request, estimate_id, *args, **kwargs):
+        response = HttpResponse(content_type='application/pdf')
+        estimate = Estimates.objects.get(pk=estimate_id)
+        response['Content-Disposition'] = 'attachment; filename="estimate.pdf"'
+        html_string = render_to_string('estimates/estimate_pdf_template.html', {
+            'estimate_number': estimate.estimate_number,  
+            # 'customer': 11,
+            # 'estimate_date': '2024-08-12',
+            # 'offer_expiry_date': '2024-08-19',
+            'title': 'Test title',
+            'content': 'Test content'
+        })
+        text_content = strip_tags(html_string)
+
+        p = canvas.Canvas(response, pagesize=letter)
+        p.drawString(30, 350, text_content)
+        p.showPage()
+        p.save()
+        return response
 
 def estimate_pdf_creation_view(request):
     buffer = io.BytesIO()

--- a/users/views.py
+++ b/users/views.py
@@ -29,11 +29,11 @@ class RegisterView(APIView):
         serializer.save()
         status_message.success(request, 'Registration succesful')
         subject = 'Welcome to invoicePro, the best open source Invoice Management System'
-        messages = f'Hi user, thank you for registering at our site.'
+        messages = f"Hi {serializer.data['username']}, thank you for registering at our site."
         email_from = 'no-reply@example.com'
         recipient_list = serializer.validated_data['email']
         send_mail(subject, messages, email_from, [recipient_list])
-        return Response(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 class LoginView(APIView):
     def post(self, request):


### PR DESCRIPTION
1. Since using ReportLab for testing pdf generation - a bug is found as dynamic content generation for the PDF is not working as expected. This might be because - ReportLab itself does not directly **support converting HTML documents into PDFs**. Instead, it uses its own APIs to create PDFs programmatically. 

2. The pdf generation process is working as expected