### PR TITLE
testing: functionality to send estimate pdf to customer through mails

### DIFF
--- a/estimates/templates/estimates/estimate_pdf_template.html
+++ b/estimates/templates/estimates/estimate_pdf_template.html
@@ -10,6 +10,7 @@
     <ul>
         <li>testing </li>
         {% for estimate_id, estimate_info in estimates.items %}
+            {% csrf_token %} 
             <li>
                 
                 <strong>Estimate number:</strong> {{ estimate_info.estimate_number }} <br>

--- a/estimates/urls.py
+++ b/estimates/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from estimates.views import EstimateListCreateView, EstimateRetrieveUpdateDeleteView, EstimateCreationView, EstimateDetailView, estimates_index, PdfGenerationView, ViewPDF
+from estimates.views import EstimateListCreateView, EstimateRetrieveUpdateDeleteView, EstimateCreationView, EstimateDetailView, estimates_index, PdfGenerationView, ViewPDF, send_estimate_to_customer
 
 
 urlpatterns = [
@@ -10,5 +10,6 @@ urlpatterns = [
     path('detail_estimate/<int:estimate_id>/', EstimateDetailView.as_view(), name='estimate-detail'),
     path('generate_pdf/<int:estimate_id>/', PdfGenerationView.as_view(), name='generate-pdf'),
     path('pdf_view/<int:estimate_id>/', ViewPDF.as_view(), name='pdf-view'),
+    path('send_estimate/<int:estimate_id>/', send_estimate_to_customer, name='send-estimate'),
     #path('index/', estimates_index, name='estimates-index'),
 ]

--- a/estimates/views.py
+++ b/estimates/views.py
@@ -1,7 +1,8 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views import View
 from django.utils.html import strip_tags
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
+from django.core.mail import EmailMessage
 from rest_framework import generics, viewsets, status, serializers
 from rest_framework.views import APIView
 from rest_framework.response import Response 
@@ -11,11 +12,10 @@ from estimates.models import Estimates, EstimateItems
 from estimates.serializers import EstimateSerializer
 from estimates.forms import EstimateForm
 
-#from django.template.response import SimpleTemplateResponse
-import io
 from io import BytesIO
 from django.http import FileResponse
 from django.template.loader import render_to_string, get_template
+from django.views.decorators.csrf import csrf_exempt
 from reportlab.pdfgen import canvas
 from xhtml2pdf import pisa
 
@@ -92,18 +92,16 @@ def render_to_pdf(template_src, context_dict={}):
     template = get_template(template_src)
     html = template.render(context_dict)
     result = BytesIO()
-    pdf = pisa.pisaDocument(BytesIO(html.encode("ISO-8859-1")), result)
-    if not pdf.err: return HttpResponse(result.getvalue(), content_type = 'application/pdf')
-    #if not pdf.err: return render(request, result.getvalue(), 'estimates/estimate_pdf_template.html', content_type = 'application/pdf')
+    pdf = pisa.pisaDocument(BytesIO(html.encode("UTF-8")), result)
+    #pdf = pisa.pisaDocument(result)
+    #pdf = pisa.CreatePDF(html, dest=result)
 
+
+    if not pdf.err: return HttpResponse(result.getvalue(), content_type = 'application/pdf')
+        #return result.getvalue()
     return None
 
-# estimate_data = {
-#     "company": "Rohit Company",
-#     "city": "Kolkata",
-#     "state": "Bengal"
-# }
-
+    
 class ViewPDF(View):
     def get(self, request, estimate_id, *args, **kwargs):
         estimate_concerned = Estimates.objects.get(pk=estimate_id)
@@ -128,9 +126,60 @@ class ViewPDF(View):
             }
         }
         
-        #pdf = render_to_pdf('estimates/estimate_pdf_template.html', estimate_data)
+        #pdf = render_to_pdf('estimates/estimate_pdf_template.html', {'estimates': estimate_data})
+        #pdf = render_to_pdf('estimates/estimate_pdf_template.html', {'estimates': 'estimate_data'})
         pdf = render_to_pdf('estimates/estimate_pdf_template.html', {'estimates': estimate_data})
+
+        # pdf = render_to_pdf(estimate_id)
+        # if pdf:
         return HttpResponse(pdf, content_type='application/pdf')
+        #     #response = HttpResponse(pdf, content_type='application/pdf')
+        #     response = HttpResponse(content_type='application/pdf')
+        #     response['Content-Disposition'] = 'attachment; filename="my_estimate.pdf"'
+        #     return response
+        # return HttpResponse("Error generating PDF", status=400)
+
+@csrf_exempt    
+def send_estimate_to_customer(self, estimate_id):
+    subject = f"New estimate {'estimate_number'} sent by Tester"
+    estimate_used = Estimates.objects.get(pk=estimate_id)
+    estimate_data = {
+            estimate_used.estimate_id: {
+                'estimate_number': estimate_used.estimate_number,
+                'customer': estimate_used.customer,
+                'estimate_date': estimate_used.estimate_date,
+                'offer_expiry_date': estimate_used.offer_expiry_date,
+                'subject': estimate_used.subject,
+                'status': estimate_used.status,
+                'customer_notes': estimate_used.customer_notes,
+                'tax_from_source_type': estimate_used.tax_from_source_type,
+                'applicable_tax_percentage': estimate_used.applicable_tax_percentage,
+                'shipping_charges_applicable': estimate_used.shipping_charges_applicable,
+                'shipping_charges': estimate_used.spipping_charges,
+                'discount_applicable': estimate_used.discount_applicable,
+                'discount_percentage': estimate_used.discount_percentage,
+                'terms_and_conditions': estimate_used.terms_and_conditions,
+                'upload_additional_files': estimate_used.upload_additional_files,
+                'total_estimate_amount': estimate_used.total_estimate_amount            
+            }
+        }
+    #pdf = render_to_pdf('estimates/estimate_pdf_template.html', {'estimates': estimate_data})
+    pdf = render_to_pdf('estimates/estimate_pdf_template.html', {'estimates': 'estimate_data'})
+
+    if pdf:
+        response = HttpResponse(pdf, content_type='application/pdf')
+        # Set the filename for the PDF
+        response['Content-Disposition'] = 'attachment; filename="my_estimate.pdf"'
+        #return response
+    from_email = 'from@yourdjangoapp.com'
+    to = 'to@yourbestuser.com'
+
+    message = EmailMessage(subject=subject, body=pdf, from_email=from_email, to=(to, ))
+    #with open('estimate.pdf') as file:
+        #message.attach('estimate.pdf', file.read(), 'file/pdf')
+    message.attach('my_estimate.pdf', pdf, 'application/pdf')
+    message.send()
+    return HttpResponse(status=status.HTTP_200_OK)
 
 def estimates_index(request):
     return render(request, 'estimates/estimates_list.html')


### PR DESCRIPTION
1. adding: send estimate to customer method and its url path
2. adding: csrf token in the estimate pdf template

**Existing problem: Mail is getting sent to the customer with the estimate pdf attachment, but the pdf content is not there in the attachment - i.e the attachment has no estimate content.**

To be fixed in later commits.